### PR TITLE
fix: Register handlers only when defined

### DIFF
--- a/.changeset/brave-birds-brush.md
+++ b/.changeset/brave-birds-brush.md
@@ -1,0 +1,5 @@
+---
+'solid-stripe': patch
+---
+
+Register handlers only when defined

--- a/src/components/createElementComponent.tsx
+++ b/src/components/createElementComponent.tsx
@@ -115,7 +115,7 @@ export const useAttachEvent = <A extends unknown[]>(
   cb?: (...args: A) => any,
 ) => {
   createEffect(() => {
-    if (!element() && !cb) {
+    if (!element() || !cb) {
       return
     }
 


### PR DESCRIPTION
Follow up fix for https://github.com/wobsoriano/solid-stripe/issues/19