### PR TITLE
Elements aren't being destroyed during onCleanup

### DIFF
--- a/src/components/createElementComponent.tsx
+++ b/src/components/createElementComponent.tsx
@@ -101,6 +101,12 @@ export const createElementComponent = ({
 
     useAttachEvent(element, 'ready', readyCallback)
 
+    onCleanup(() => {
+      if (typeof element()?.destroy == 'function') {
+        element()!.destroy()
+      }
+    })
+
     return <div id={props.id} class={props.class} ref={setDomRef}></div>
   }
 


### PR DESCRIPTION
This issue causes the error "Can only create one Element of type payment." under some conditions

- When HMR re-renders the page
- When an Element is used inside a <Show> block and hidden/shown